### PR TITLE
Add bootstrap log entries for 'arcjobs' and 'jobdescriptions' tables

### DIFF
--- a/src/act/arc/aCTDBArc.py
+++ b/src/act/arc/aCTDBArc.py
@@ -113,6 +113,7 @@ class aCTDBArc(aCTDB):
             c.execute("drop table arcjobs")
 
         # Create arcjobs
+        self.log.info("creating arcjobs table")
         try:
             c.execute(create)
             self.Commit()
@@ -121,6 +122,7 @@ class aCTDBArc(aCTDB):
             return False
 
         # Create job description table
+        self.log.info("creating jobdescriptions table")
         create="""CREATE TABLE jobdescriptions (
             id INTEGER PRIMARY KEY AUTO_INCREMENT,
             jobdescription mediumtext)


### PR DESCRIPTION
Log of successful bootstrap appears as if it creates only proxies table.